### PR TITLE
Handle newlines at start/end of CSV field

### DIFF
--- a/lib/sequel/extensions/csv_to_parquet.rb
+++ b/lib/sequel/extensions/csv_to_parquet.rb
@@ -106,7 +106,7 @@ module Sequel::CsvToParquet
                 else
                   col.gsub!(comma, comma_rep)
                 end
-                input.write(col)
+                input.write(col.strip)
                 input.write(comma)
               end
 


### PR DESCRIPTION
There appear to be some embedded newlines at the end of some fields
in the OMOP vocabulary files.

:empty_null => :ruby will now call #strip on each field